### PR TITLE
Fix: Freeze anyio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.85.0
 pytest==7.1.2
 uvicorn==0.18.3
 requests==2.28.1
+anyio==3.6.1


### PR DESCRIPTION
If anyio moves to version 4.0.0 (30/08/2023), the test suite
test_calculation_endpoints.py fails with error:
AttributeError: module 'anyio' has no attribute 'start_blocking_portal'